### PR TITLE
Add an example to the docs around custom search patterns that need to match literal quotes

### DIFF
--- a/README.md
+++ b/README.md
@@ -372,6 +372,27 @@ replace = MyProject=={new_version}
 
   Can be multiple lines, templated using [Python Format String Syntax](https://docs.python.org/3/library/string.html#format-string-syntax).
 
+  **NOTE**: (*Updated in v1.0.1*) It is important to point out that if a
+  custom search pattern is configured, then `bump2version` will only perform
+  a change if it finds an exact match and will not fallback to the default
+  pattern. This is to prevent accidentally changing strings that match the
+  default pattern when there is a typo in the custom search pattern.
+
+  For example, if the string to be replaced includes literal quotes,
+  the search and replace patterns must include them too to match. Given the
+  file `version.sh`:
+
+      MY_VERSION="1.2.3"
+
+  Then the following search and replace patterns (including quotes) would be
+  required:
+
+```ini
+[bumpversion:file:version.sh]
+search = MY_VERSION="{current_version}"
+replace = MY_VERSION="{new_version}"
+```
+
 ## Command-line Options
 
 Most of the configuration values above can also be given as an option on the command-line.


### PR DESCRIPTION
A bugfix in v1.0.1 has introduced confusion for some users. This update aims to make clear the intended behaviour and configuration required for their use case.

Up until v1.0.0, a misconfigured custom search pattern could silently fallback to the default pattern and perform a match, leading the users to believe their configuration was working. In v1.0.1 that bug was fixed to avoid accidentally changing files with the default pattern when there was a typo in the custom pattern.

I believe the new behaviour is correct, and with the right configuration their use case is supported in both <=v1.0.1 AND >=v1.0.1 releases. The best thing we can do here is to update the docs to be as clear as possible.

Cheers,
Kyle
